### PR TITLE
Allow suffix to be written to condor submit log, output, and error files

### DIFF
--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -53,6 +53,9 @@ class Job(BaseNode):
     output : str or None, optional
         Path to directory where condor Job output files will be written
         (default is None, will not be included in Job submit file).
+    
+    suffix: str or None, optional
+        Suffix to append to output, log, and error files in the submit file.
 
     submit : str, optional
         Path to directory where condor Job submit files will be written
@@ -136,7 +139,7 @@ class Job(BaseNode):
     """
 
     def __init__(self, name, executable, error=None, log=None, output=None,
-                 submit=None, request_memory=None, request_disk=None,
+                 suffix=None, submit=None, request_memory=None, request_disk=None,
                  request_cpus=None, getenv=None, universe=None,
                  initialdir=None, notification=None, requirements=None,
                  queue=None, extra_lines=None, dag=None, arguments=None,
@@ -148,6 +151,7 @@ class Job(BaseNode):
         self.error = error
         self.log = log
         self.output = output
+        self.suffix = suffix
         self.request_memory = request_memory
         self.request_disk = request_disk
         self.request_cpus = request_cpus
@@ -297,14 +301,12 @@ class Job(BaseNode):
                 dir_path = dir_env_var
             else:
                 continue
-
-            # Add log/output/error files to submit file lines
-            if self._has_arg_names:
-                file_path = os.path.join(dir_path,
-                                         '$(job_name).{}'.format(attr))
-            else:
-                file_path = os.path.join(dir_path,
-                                         '{}.{}'.format(name, attr))
+                
+            suffix = self.suffix if self.suffix is not None else ''
+            job_name = name if not self._has_arg_names else '$(job_name)'
+            
+            file_path = os.path.join(dir_path, "{}{}.{}".format(job_name, suffix, attr))
+        
             lines.append('{} = {}'.format(attr, file_path))
             setattr(self, '{}_file'.format(attr), file_path)
             checkdir(file_path, makedirs)

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -53,7 +53,7 @@ class Job(BaseNode):
     output : str or None, optional
         Path to directory where condor Job output files will be written
         (default is None, will not be included in Job submit file).
-    
+
     suffix: str or None, optional
         Suffix to append to output, log, and error files in the submit file.
 
@@ -301,12 +301,12 @@ class Job(BaseNode):
                 dir_path = dir_env_var
             else:
                 continue
-                
+
             suffix = self.suffix if self.suffix is not None else ''
             job_name = name if not self._has_arg_names else '$(job_name)'
-            
+
             file_path = os.path.join(dir_path, "{}{}.{}".format(job_name, suffix, attr))
-        
+
             lines.append('{} = {}'.format(attr, file_path))
             setattr(self, '{}_file'.format(attr), file_path)
             checkdir(file_path, makedirs)

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -330,17 +330,17 @@ def test_init_retry_type_fail():
 
 def test_job_suffix(tmpdir):
     job = Job(
-        'jobname', 
-        example_script, 
+        'jobname',
+        example_script,
         suffix='-suffix',
-        log = str(tmpdir.join('log')),
-        error = str(tmpdir.join('error')),
-        output = str(tmpdir.join('output')), 
+        log=str(tmpdir.join('log')),
+        error=str(tmpdir.join('error')),
+        output=str(tmpdir.join('output')), 
     )
     job.build()
     with open(job.submit_file, 'r') as f:
         lines = f.readlines()
-    
+
     for attr in ['log', 'error', 'output']:
         for line in lines:
             if line.startswith(attr):

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -335,7 +335,7 @@ def test_job_suffix(tmpdir):
         suffix='-suffix',
         log=str(tmpdir.join('log')),
         error=str(tmpdir.join('error')),
-        output=str(tmpdir.join('output')), 
+        output=str(tmpdir.join('output')),
     )
     job.build()
     with open(job.submit_file, 'r') as f:

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -326,3 +326,22 @@ def test_init_retry_type_fail():
         job_with_retry.build()
     error = 'retry must be an int'
     assert error == str(excinfo.value)
+
+
+def test_job_suffix(tmpdir):
+    job = Job(
+        'jobname', 
+        example_script, 
+        suffix='-suffix',
+        log = str(tmpdir.join('log')),
+        error = str(tmpdir.join('error')),
+        output = str(tmpdir.join('output')), 
+    )
+    job.build()
+    with open(job.submit_file, 'r') as f:
+        lines = f.readlines()
+    
+    for attr in ['log', 'error', 'output']:
+        for line in lines:
+            if line.startswith(attr):
+                assert f'-suffix.{attr}' in line


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/jrbourbeau/pycondor/issues) if one exists. For example,

Fixes #<ISSUE_NUMBER>
-->


#### What does this pull request implement/fix? Explain your changes.
Adds `Optional` `suffix` attribute to `Job` which will append a specified `suffix` to the output, error, and log files specified in the condor submit. 

Useful when using `queue from ...` syntax, and want to specify unique,  dynamic output, error, and log files for each individual job via Condor expressions 


#### Any other comments?
